### PR TITLE
Use npm scripts instead of grunt directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ yo kibana-plugin
 Assuming you've setup a [Kibana development enviroment](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#development-environment-setup) at the same level as your plugin directory (an named it `kibana`). Then run the following command inside your plugin directory.
 
 ```
-gulp dev
+npm start
 ```
 
 With Elasticsearch already running you should now start Kibana in dev mode.

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "description": "<%= description %>",
   "main": "gulpfile.js",
+  "scripts": {
+    "start": "gulp dev",
+    "build": "gulp build",
+    "package": "gulp package"
+  },
   "devDependencies": {
   }
 }


### PR DESCRIPTION
This way, if you ever replace gulp, nothing changes for the user

We do this in Kibana, and I think it's a good practice
