### PR TITLE
Use babel-eslint, add test script

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -37,6 +37,7 @@ module.exports = generator.Base.extend({
     var deps = [
       'gulp',
       'bluebird',
+      'babel-eslint',
       'gulp-eslint',
       'gulp-gzip',
       'gulp-tar',
@@ -84,6 +85,10 @@ module.exports = generator.Base.extend({
       this.templatePath('server/routes/example.js'),
       this.destinationPath('server/routes/example.js'),
       vars
+    );
+    this.fs.copy(
+      this.templatePath('.eslintrc'),
+      this.destinationPath('.eslintrc')
     );
     this.fs.copy(
       this.templatePath('gulpfile.js'),

--- a/generators/app/templates/.eslintrc
+++ b/generators/app/templates/.eslintrc
@@ -1,0 +1,9 @@
+---
+parser: babel-eslint
+
+env:
+  es6: true
+  amd: true
+  node: true
+  mocha: true
+  browser: true

--- a/generators/app/templates/.eslintrc
+++ b/generators/app/templates/.eslintrc
@@ -1,9 +1,75 @@
 ---
 parser: babel-eslint
 
+plugins:
+  - mocha
+
 env:
   es6: true
   amd: true
   node: true
   mocha: true
   browser: true
+
+
+rules:
+  block-scoped-var: 2
+  camelcase: [ 2, { properties: never } ]
+  comma-dangle: 0
+  comma-style: [ 2, last ]
+  consistent-return: 0
+  curly: [ 2, multi-line ]
+  dot-location: [ 2, property ]
+  dot-notation: [ 2, { allowKeywords: true } ]
+  eqeqeq: [ 2, allow-null ]
+  guard-for-in: 2
+  indent: [ 2, 2, { SwitchCase: 1 } ]
+  key-spacing: [ 0, { align: value } ]
+  max-len: [ 2, 140, 2, { ignoreComments: true, ignoreUrls: true } ]
+  new-cap: [ 2, { capIsNewExceptions: [ Private ] } ]
+  no-bitwise: 0
+  no-caller: 2
+  no-cond-assign: 0
+  no-debugger: 2
+  no-empty: 2
+  no-eval: 2
+  no-extend-native: 2
+  no-extra-parens: 0
+  no-irregular-whitespace: 2
+  no-iterator: 2
+  no-loop-func: 2
+  no-multi-spaces: 0
+  no-multi-str: 2
+  no-nested-ternary: 2
+  no-new: 0
+  no-path-concat: 0
+  no-proto: 2
+  no-return-assign: 0
+  no-script-url: 2
+  no-sequences: 2
+  no-shadow: 0
+  no-trailing-spaces: 2
+  no-undef: 2
+  no-underscore-dangle: 0
+  no-unused-expressions: 0
+  no-unused-vars: 0
+  no-use-before-define: [ 2, nofunc ]
+  no-with: 2
+  one-var: [ 2, never ]
+  quotes: [ 2, single ]
+  semi-spacing: [ 2, { before: false, after: true } ]
+  semi: [ 2, always ]
+  space-after-keywords: [ 2, always ]
+  space-before-blocks: [ 2, always ]
+  space-before-function-paren: [ 2, { anonymous: always, named: never } ]
+  space-in-parens: [ 2, never ]
+  space-infix-ops: [ 2, { int32Hint: false } ]
+  space-return-throw-case: [ 2 ]
+  space-unary-ops: [ 2 ]
+  strict: [ 2, never ]
+  valid-typeof: 2
+  wrap-iife: [ 2, outside ]
+  yoda: 0
+
+  mocha/no-exclusive-tests: 2
+  mocha/handle-done-callback: 2

--- a/generators/app/templates/gulpfile.js
+++ b/generators/app/templates/gulpfile.js
@@ -1,7 +1,7 @@
 var gulp = require('gulp');
 var _ = require('lodash');
 var path = require('path');
-var gulpUtil = require('gulp-util');
+var gutil = require('gulp-util');
 var mkdirp = require('mkdirp');
 var Rsync = require('rsync');
 var Promise = require('bluebird');
@@ -78,6 +78,10 @@ gulp.task('lint', function (done) {
     // To have the process exit with an error code (1) on
     // lint error, return the stream and pipe to failOnError last.
     .pipe(eslint.failOnError());
+});
+
+gulp.task('test', ['lint'], function () {
+  gutil.log(gutil.colors.red('Nothing to test...'));
 });
 
 gulp.task('clean', function (done) {

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "gulp dev",
     "build": "gulp build",
-    "package": "gulp package"
+    "package": "gulp package",
+    "test": "gulp test"
   },
   "devDependencies": {
   }


### PR DESCRIPTION
We support es6 syntax via babel, so we should allow it to lint correctly.
- Adds babel-eslint dep
- Adds simple `.eslintrc` file
- Uses babel-eslint as the eslint parser
- Add `npm run test` script which uses the linter
  - Also provides a placeholder for adding real tests
