### PR TITLE
Use babel-register with es2015 in gulpfile

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -38,6 +38,8 @@ module.exports = generator.Base.extend({
       'gulp',
       'bluebird',
       'babel-eslint',
+      'babel-preset-es2015',
+      'babel-register',
       'eslint-plugin-mocha',
       'gulp-eslint',
       'gulp-gzip',

--- a/generators/app/templates/gulpfile.js
+++ b/generators/app/templates/gulpfile.js
@@ -1,3 +1,7 @@
+require('babel-register')({
+  presets: ['es2015']
+});
+
 var gulp = require('gulp');
 var _ = require('lodash');
 var path = require('path');


### PR DESCRIPTION
Since Kibana allows the use of es2015 code, plugin developers can seamlessly use it in their code as well. The issue, however, is when writing tests against that code, as plugin tests run in isolation, outside of Kibana. 

This PR adds [babel-register](https://babeljs.io/docs/usage/require/) to the gulpfile and includes the es2015 plugin by default. This is sufficient to run tests, as the gulpfile is the entry point, and all files `require`'d from the gulpfile will be run through babel.
