### PR TITLE
fixed typo in gulpfile (bable -> babel)

### DIFF
--- a/src/generators/app/templates/gulpfile.babel.js
+++ b/src/generators/app/templates/gulpfile.babel.js
@@ -33,7 +33,7 @@ const include = [
 
 const exclude = [
   'gulpfile.babel.js',
-  '.bablerc',
+  '.babelrc',
   '.eslintrc'
 ];
 


### PR DESCRIPTION
due to this typo, the `.babelrc` file was copied too and confused the hell out of Kibana
