### PR TITLE
Add --minimal and --advanced options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,11 @@ bin/kibana --dev
 ```
 
 Visit [http://localhost:5601](http://localhost:5601)
+
+## options
+
+If you start the generator with the `--minimal` flag, it will not generate any sample code only
+the bare folder structure.
+
+If you start the generator with the `--advanced` flag, you can choose what sample
+components it should generate for you.

--- a/src/generators/app/index.js
+++ b/src/generators/app/index.js
@@ -6,6 +6,8 @@ module.exports = generator.Base.extend({
 
   constructor: function () {
     generator.Base.apply(this, arguments);
+    this.option('advanced');
+    this.option('minimal');
   },
 
   promptingPluginName: function () {
@@ -34,15 +36,87 @@ module.exports = generator.Base.extend({
     }.bind(this));
   },
 
+  promptingGenerateApp: function() {
+    if (!this.options.advanced) {
+      this.generateApp = !this.options.minimal;
+      return;
+    }
+    var done = this.async();
+    this.prompt({
+      type: 'confirm',
+      name: 'generateApp',
+      message: 'Should an app component be generated?',
+      default: ''
+    }, function (answers) {
+      this.generateApp = answers.generateApp;
+      done();
+    }.bind(this));
+  },
+
+  promptingGenerateHack: function() {
+    if (!this.options.advanced) {
+      this.generateHack = !this.options.minimal;
+      return;
+    }
+    var done = this.async();
+    this.prompt({
+      type: 'confirm',
+      name: 'generateHack',
+      message: 'Should an hack component be generated?',
+      default: ''
+    }, function (answers) {
+      this.generateHack = answers.generateHack;
+      done();
+    }.bind(this));
+  },
+
+  promptingGenerateApi: function() {
+    if (!this.options.advanced) {
+      this.generateApi = !this.options.minimal;
+      return;
+    }
+    var done = this.async();
+    this.prompt({
+      type: 'confirm',
+      name: 'generateApi',
+      message: 'Should a server API be generated?',
+      default: ''
+    }, function (answers) {
+      this.generateApi = answers.generateApi;
+      done();
+    }.bind(this));
+  },
+
   writing: function () {
     var vars = {
       name: this.appname,
+      generateApi: this.generateApi,
+      generateApp: this.generateApp,
+      generateHack: this.generateHack,
       description: this.description,
       title: _.startCase(this.appname),
       camelCaseName: _.camelCase(this.appname)
     };
 
-    var input = [this.templatePath('**/*'), this.templatePath('**/.*')];
+    var input = [
+      this.templatePath('*'),
+      this.templatePath('.*')
+    ];
+
+    if (this.generateApi) {
+      input.push(this.templatePath('server/**/*'));
+    }
+
+    if (this.generateHack) {
+      input.push(this.templatePath('public/hack.js'));
+    }
+
+    if (this.generateApp) {
+      input.push(this.templatePath('public/app.js'));
+      input.push(this.templatePath('public/less/main.less'));
+      input.push(this.templatePath('public/templates/index.html'));
+    }
+
     return this.fs.copyTpl(input, '', vars);
   },
 

--- a/src/generators/app/templates/index.js
+++ b/src/generators/app/templates/index.js
@@ -1,18 +1,22 @@
-import exampleRoute from './server/routes/example';
+<% if (generateApi) { %>import exampleRoute from './server/routes/example';<% } %>
 
 export default function (kibana) {
   return new kibana.Plugin({
     require: ['elasticsearch'],
 
     uiExports: {
+      <% if (generateApp) { %>
       app: {
         title: '<%= title %>',
         description: '<%= description %>',
         main: 'plugins/<%= name %>/app'
       },
+      <% } %>
+      <% if (generateHack) { %>
       hacks: [
         'plugins/<%= name %>/hack'
       ]
+      <% } %>
     },
 
     config(Joi) {
@@ -21,10 +25,12 @@ export default function (kibana) {
       }).default();
     },
 
+    <% if (generateApi) { %>
     init(server, options) {
       // Add server routes and initalize the plugin here
       exampleRoute(server);
     }
+    <% } %>
 
   });
 };


### PR DESCRIPTION
When specifying the `--minimal` option to the generator, it won't create all the sample components, useful if you are knowing what you do, and just would like the build system without any code you have to delete afterwards.

When specifying the `--advanced` option, the generator will ask you what components to generate and you have full control over what sample files you need.
