### PR TITLE
Components subgenerators

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "generator-git-init": "^1.1.1",
-    "lodash": "^3.10.1",
+    "lodash": "^4.5.0",
     "yeoman-generator": "^0.20.3"
   },
   "devDependencies": {

--- a/src/generators/app/templates/index.js
+++ b/src/generators/app/templates/index.js
@@ -1,10 +1,24 @@
 <% if (generateApi) { %>import exampleRoute from './server/routes/example';<% } %>
 
+import fs from 'fs';
+import path from 'path';
+
+function getAll(type) {
+  try {
+    return fs.readdirSync(path.join(__dirname, 'public', type)).map(file => {
+      return `plugins/<%= name %>/${type}/${file.replace(/\.js$/, '')}`;
+    });
+  } catch (e) {
+    return [];
+  }
+}
+
 export default function (kibana) {
   return new kibana.Plugin({
     require: ['elasticsearch'],
 
     uiExports: {
+      fieldFormats: getAll('field_formats'),
       <% if (generateApp) { %>
       app: {
         title: '<%= title %>',

--- a/src/generators/field-format/index.js
+++ b/src/generators/field-format/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var yeoman = require('yeoman-generator');
+import * as yeoman from 'yeoman-generator';
 import _ from 'lodash';
 
 module.exports = yeoman.generators.Base.extend({
@@ -36,6 +36,6 @@ module.exports = yeoman.generators.Base.extend({
         id: _.camelCase(this.props.name)
       }
     );
-  },
+  }
 
 });

--- a/src/generators/field-format/index.js
+++ b/src/generators/field-format/index.js
@@ -13,7 +13,7 @@ module.exports = yeoman.generators.Base.extend({
     },{
       type: 'checkbox',
       name: 'fieldTypes',
-      message: 'For which field types will this converter work?',
+      message: 'For which field types will this formatter work?',
       choices: ['string', 'number', 'boolean', 'date', 'ip', 'attachment', 'geo_point', 'geo_shape', 'murmur3', 'unknown'],
       validate: (value) => {
         return value.length ? true : "You have to specify at least one type.";

--- a/src/generators/field-format/index.js
+++ b/src/generators/field-format/index.js
@@ -1,0 +1,41 @@
+'use strict';
+var yeoman = require('yeoman-generator');
+import _ from 'lodash';
+
+module.exports = yeoman.generators.Base.extend({
+  prompting: function () {
+    var done = this.async();
+
+    var prompts = [{
+      type: 'input',
+      name: 'name',
+      message: 'Enter the titel of the field format I should create?'
+    },{
+      type: 'checkbox',
+      name: 'fieldTypes',
+      message: 'For which field types will this converter work?',
+      choices: ['string', 'number', 'boolean', 'date', 'ip', 'attachment', 'geo_point', 'geo_shape', 'murmur3', 'unknown'],
+      validate: (value) => {
+        return value.length ? true : "You have to specify at least one type.";
+      }
+    }];
+
+    this.prompt(prompts, (props) => {
+      this.props = props;
+      done();
+    });
+  },
+
+  writing: function () {
+    this.fs.copyTpl(
+      this.templatePath('field_format.js'),
+      this.destinationPath(`public/field_formats/${_.snakeCase(this.props.name)}.js`),
+      {
+        ...this.props,
+        className: _.upperFirst(_.camelCase(this.props.name)),
+        id: _.camelCase(this.props.name)
+      }
+    );
+  },
+
+});

--- a/src/generators/field-format/templates/field_format.js
+++ b/src/generators/field-format/templates/field_format.js
@@ -1,0 +1,28 @@
+import fieldFormatRegistry from 'ui/registry/field_formats';
+import FieldFormat from 'ui/index_patterns/_field_format/FieldFormat';
+import _ from 'lodash';
+
+fieldFormatRegistry.register((Private) => {
+  _.class(<%= className %>).inherits(Private(FieldFormat));
+  function <%= className %>(params) {
+    <%= className %>.Super.call(this, params);
+  }
+
+  <%= className %>.id = '<%= id %>';
+  <%= className %>.title = '<%= name %>';
+
+  <%= className %>.fieldType = <%- JSON.stringify(fieldTypes) %>;
+
+  <%= className %>.prototype._convert = {
+    text: function (value) {
+      // This method must return a textual representation of the value (no HTML).
+      return value;
+    },
+    html: function (value) {
+      // This method can return HTML to represent the value.
+      return value;
+    }
+  };
+
+  return <%= className %>;
+});


### PR DESCRIPTION
Hi @spalger,

this branch has a first draft of a components subgenerator in it. It has a field format subgenerator, that can be called with `yo kibana-plugin:field-format` and will generate new files. Also it has the auto detecting feature in the main generator for field formats right now.

Every feedback highly welcome. If this is a base one could work of, we could create several subgenerators for the different components, link them up in the main generator and - imo - throw away the "old" sample components in the main generator.
