### PR TITLE
Add deprecation notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Kibana Plugin Yeoman Generator
 
+[![Apache License](https://img.shields.io/badge/license-apache_2.0-a9215a.svg)](https://raw.githubusercontent.com/elastic/template-kibana-plugin/master/LICENSE)
+[![Package Deprecated](https://img.shields.io/badge/status-deprecated-red.svg)](https://github.com/elastic/template-kibana-plugin/)
+
+**DEPRECATION NOTICE**: This package is being deprecated in favor of [template-kibana-plugin](https://github.com/elastic/template-kibana-plugin/)
+
+---
+
 This project is a Yeoman generator for bootstrapping a Kibana Plugin. It creates a basic hello world Kibana plugin with all the elements in place so you can easily get started with creating your first Kibana plugin.
 
 ## Getting Started


### PR DESCRIPTION
I'd like to deprecate the generator in favor of the [plugin template](https://github.com/elastic/template-kibana-plugin/). I think it's a lot easier to maintain the template than this generator, plus, it has some nice extras.

- It has [proper testing](https://github.com/elastic/template-kibana-plugin/blob/master/sao.test.js)
- It's configured to [install dependencies *and* initialize git](https://github.com/elastic/template-kibana-plugin/blob/master/sao.js#L54-L55)
- It correctly prompts user for what to include, which yeoman is configured for, but doesn't actually do (see image below)

This PR just adds a note to the README. We'll also likely want to update the repo description on github, and add a notice to the npm packages.

![screenshot 2017-06-15 10 44 46](https://user-images.githubusercontent.com/404731/27196778-b24f5c2e-51c0-11e7-85ef-65b1e34e9577.jpg)

---

If folks are opposed to this happening, this is the place to mention it.